### PR TITLE
Update README to use oauth2 route instead of oauth

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ export default buildConfig({
       clientSecret: process.env.CLIENT_SECRET,
       authorizationURL: process.env.OAUTH_SERVER + '/oauth/authorize',
       tokenURL: process.env.OAUTH_SERVER + '/oauth/token',
-      callbackURL: process.env.SERVER_URL + '/oauth/callback',
+      callbackURL: process.env.SERVER_URL + '/oauth2/callback',
       scope: 'basic',
       async userinfo(accessToken) {
         const { data: user } = await axios.get(OAUTH_SERVER + '/oauth/me', {


### PR DESCRIPTION
Hi.

Your code applies the express-session middleware in oauth2/* routes, and the README gives oauth/ as an callback URL example, this breaks the default example as passport complies about no "express-session" middleware found in that route.