### PR TITLE
Fix error if payload config haven't admin.webpack

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -187,7 +187,7 @@ function oAuthPluginServer(
     admin: {
       ...incoming.admin,
       webpack: (webpackConfig) => {
-        const config = incoming.admin?.webpack?.(webpackConfig) || {}
+        const config = incoming.admin?.webpack?.(webpackConfig) || webpackConfig
         return {
           ...config,
           resolve: {


### PR DESCRIPTION
I found that if payload config haven't `admin.webpack` function than Payload run process stuck with following error:

```bash
uj-payload-payload-1  | error - unhandledRejection: TypeError: Cannot read properties of undefined (reading 'publicPath')
uj-payload-payload-1  |     at initWebpack (/home/node/app/node_modules/payload/src/webpack/init.ts:15:41)
uj-payload-payload-1  |     at initAdmin (/home/node/app/node_modules/payload/src/express/admin.ts:29:34)
uj-payload-payload-1  |     at initHTTP (/home/node/app/node_modules/payload/src/initHTTP.ts:51:14)
uj-payload-payload-1  |     at processTicksAndRejections (node:internal/process/task_queues:95:5)
uj-payload-payload-1  |     at Payload.init (/home/node/app/node_modules/payload/src/index.ts:14:21)
```

This change should fix that.