### PR TITLE
initialize payload variable onInit-call

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ import jwt from 'jsonwebtoken'
 import passport from 'passport'
 import OAuth2Strategy, { VerifyCallback } from 'passport-oauth2'
 import debug from 'debug'
-import payload from 'payload'
+import  { Payload } from 'payload'
 import { Config } from 'payload/config'
 import {
   Field,
@@ -27,7 +27,8 @@ const log = debug('plugin:oauth')
 
 // Detect client side because some dependencies may be nullified
 const CLIENTSIDE = typeof session !== 'function'
-
+// create a variable to hold the payload instance, that is assigned in the onInit function
+let payload:Payload
 /**
  * Example for Wordpress:
  *
@@ -309,5 +310,11 @@ function oAuthPluginServer(
         },
       },
     ]),
+    onInit: async (_payload) => {
+      // await incoming config onInit
+      if (incoming.onInit) await incoming.onInit(_payload);
+      // assign payload to local variable
+      payload = _payload;
+    },
   }
 }


### PR DESCRIPTION
With the following `payload.config.ts` file:
```typescript
import OAuthButton from "./OAuthButton";
import Media from "./collections/Media";
import Pages from "./collections/Pages";
import Topics from "./collections/Topics";
import Users from "./collections/Users";
import Footer from "./globals/Footer";
import LandingPage from "./globals/LandingPage";
import MainNavigation from "./globals/MainNavigation";

import { buildConfig } from "payload/config";
import { LexicalPlugin } from "payload-plugin-lexical";

import path from "path";
const { CLIENT_ID, CLIENT_SECRET, MONGODB_URI } = process.env;
const SERVER_URL = process.env.SERVER_URL || "http://localhost:3000";
export default buildConfig({
  admin: {
    user: Users.slug
  },
  collections: [Users, Pages, Media, Topics],
  globals: [MainNavigation, LandingPage, Footer],
  typescript: {
    outputFile: path.resolve(__dirname, "payload-types.ts"),
  },
  localization: {
    locales: ["fi", "en"],
    defaultLocale: "fi",
    fallback: true,
  },
  plugins: [
    LexicalPlugin({}),
    async (config) => {
      const { oAuthPlugin } = await import("payload-plugin-oauth");
      return oAuthPlugin({
        mongoUrl: MONGODB_URI,
        clientID: CLIENT_ID,
        clientSecret: CLIENT_SECRET,
        authorizationURL: "https://accounts.google.com/o/oauth2/v2/auth",
        tokenURL: "https://www.googleapis.com/oauth2/v4/token",
        callbackURL: `${SERVER_URL}/oauth2/callback`,
        scope: ["profile", "email"],
        async userinfo(accessToken) {
          const user = await fetch(
            `https://www.googleapis.com/oauth2/v3/userinfo?access_token=${accessToken}`,
          ).then((res) => {
            if (!res.ok) {
              console.error(res);
              throw new Error(res.statusText);
            }
            return res.json() as unknown as {
              sub: string;
              name: string;
              given_name: string;
              family_name: string;
              email: string;
            };
          });
          return {
            sub: user.sub,

            // Custom fields to fill in if user is created
            name:
              user.name ||
              `${user.given_name} ${user.family_name}` ||
              "Nameless",
            email: user.email,
          };
        },
        components: {
          Button: OAuthButton,
        },
        userCollection: Users,
      })(config);
    },
  ],
});
```

and `server.ts`:
```typescript
import dotenv from "dotenv";
import express from "express";
import payload from "payload";

dotenv.config();

const app = express();

// Redirect root to Admin panel
app.get("/", (_, res) => {
  res.redirect("/admin");
});

const start = async () => {
  // Initialize Payload

  await payload.init({
    secret: process.env.PAYLOAD_SECRET,
    mongoURL: process.env.MONGODB_URI,
    express: app,
    onInit: (payload) => {
      payload.logger.info(`Payload Admin URL: ${payload.getAdminURL()}`);
    },
  });

  app.listen(3001);
};

void start();
```

The plugin crashes saying `no collection for slug "users"`, even though they exist. This seems to happen because the plugin imports payload happening prior to the proper initialization.

Proposed fix made with this PR is to instead of importing `payload`, we assign it to the variable in the `onInit`-function.