### PR TITLE
Add config option to define a redirection path for the authenticated user

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -34,7 +34,7 @@ const CLIENTSIDE = typeof session !== 'function'
  * ```
  * export function mijnNederlandsAuth() {
  *   return oAuthPlugin({
- *     mongoUrl: process.env.MONGO_URL,
+ *     databaseUri: process.env.MONGO_URL,
  *     clientID: process.env.OAUTH_CLIENT_ID,
  *     clientSecret: process.env.OAUTH_CLIENT_SECRET,
  *     authorizationURL: process.env.OAUTH_SERVER + '/oauth/authorize',
@@ -306,8 +306,9 @@ function oAuthPluginServer(
             domain: collectionConfig.auth.cookies.domain || undefined,
           })
 
-          // Redirect to admin dashboard
-          res.redirect('/admin')
+          // Redirect to the defined path or default to the admin dashboard
+          const userRedirectionPath = options.userRedirectionPath || '/admin'
+          res.redirect(userRedirectionPath)
         },
       },
     ]),

--- a/src/types.ts
+++ b/src/types.ts
@@ -58,4 +58,6 @@ export interface oAuthPluginOptions extends StrategyOptions {
     /** Defaults to "sub" */
     name?: string
   }
+  /** Which path to redirect the authenticated user to, redirects to /admin by default */
+  userRedirectionPath?: string
 }


### PR DESCRIPTION
- Fix the example configuration
- Add `userRedirectionPath` a new optional parameter in the configuration to define a path where the authenticated user can be redirect to instead of the admin dashboard. If not set, the user will be redirect to `/admin` as previously intended.