### PR TITLE
Add support for OAuth 2.0 State

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "clean": "rm -rf dist",
     "build": "tsc",
     "fix": "npx prettier src --write",
-    "prepare": "yarn fix && yarn clean && yarn build",
+    "prepare": "npm run fix && npm run clean && npm run build",
     "test": "vitest"
   },
   "exports": {


### PR DESCRIPTION
Currently, adding `state: true` to the plugin options does not work and produces an error, even though the underlying passport strategy supports it.

This change makes it work.